### PR TITLE
chore: remove artifact-repositories configmap 

### DIFF
--- a/argocon2022/install/install-workflows/quick-start-postgres.yaml
+++ b/argocon2022/install/install-workflows/quick-start-postgres.yaml
@@ -1535,39 +1535,6 @@ metadata:
   namespace: argo
 ---
 apiVersion: v1
-data:
-  default-v1: |
-    archiveLogs: true
-    s3:
-      bucket: my-bucket
-      endpoint: minio:9000
-      insecure: true
-      accessKeySecret:
-        name: my-minio-cred
-        key: accesskey
-      secretKeySecret:
-        name: my-minio-cred
-        key: secretkey
-  empty: ""
-  my-key: |
-    archiveLogs: true
-    s3:
-      bucket: my-bucket
-      endpoint: minio:9000
-      insecure: true
-      accessKeySecret:
-        name: my-minio-cred
-        key: accesskey
-      secretKeySecret:
-        name: my-minio-cred
-        key: secretkey
-kind: ConfigMap
-metadata:
-  annotations:
-    workflows.argoproj.io/default-artifact-repository: default-v1
-  name: artifact-repositories
----
-apiVersion: v1
 kind: Secret
 metadata:
   labels:


### PR DESCRIPTION
remove artifact-repositories configmap since 'archiveLogs: true' causes pod to attempt to save main log in minio which fails due to minio running in different namespace

Signed-off-by: Julie Vogelman <julie_vogelman@intuit.com>